### PR TITLE
Added zsh completion

### DIFF
--- a/completion/zsh/_ego
+++ b/completion/zsh/_ego
@@ -1,13 +1,21 @@
-#compdef epro
+#compdef epro ego
 
 PROFILE_DIR="/usr/portage/profiles/funtoo/1.0/linux-gnu"
+
+_ego-modulelist() {
+  local -a modules
+
+  modules=( 'profile' )
+
+  _values 'Modules' $modules && ret=0
+}
 
 _epro-actionlist() {
   local -a actions
 
   actions=( 'show' 'list' 'flavor' 'mix-ins' 'subarch' 'arch' 'build' )
 
-  _values 'Actions' $actions && return 0
+  _values 'Actions' $actions && ret=0
 }
 
 _epro-list() {
@@ -15,7 +23,7 @@ _epro-list() {
 
   profiles=( 'flavor' 'mix-ins' 'subarch' 'arch' 'build' )
 
-  _values 'Profiles' $profiles && return 0
+  _values 'Profiles' $profiles && ret=0
 }
 
 _epro-fetch-choices() {
@@ -27,7 +35,7 @@ _epro-fetch-choices() {
 
   _call_program help-command "ls -1 $PROFILE_DIR/$profile" | while read -A line; do choices=($line $choices) done
 
-  _values "Choices" $choices && return 0
+  _values "Choices" $choices && ret=0
 }
 
 _epro-mixins-choices() {
@@ -38,7 +46,7 @@ _epro-mixins-choices() {
 
   _call_program help-command "ls -1 $PROFILE_DIR/mix-ins" | while read -A line; do choices=(+$line -$line $choices) done
 
-  _values "Choices" $choices && return 0
+  _values "Choices" $choices && ret=0
 }
 
 _epro-subarch-choices() {
@@ -48,10 +56,10 @@ _epro-subarch-choices() {
 
   _call_program help-command "ls -1 $PROFILE_DIR/arch/$arch/subarch" | while read -A line; do choices=($line $choices) done
 
-  _values "Choices" $choices && return 0
+  _values "Choices" $choices && ret=0
 }
 
-_epro() {
+_ego-profile() {
   local curcontext="$curcontext" ret=1
 
   if ((CURRENT == 2)); then
@@ -69,4 +77,18 @@ _epro() {
   fi
 }
 
-compdef _epro epro
+_ego() {
+  local curcontext="$curcontext" ret=1
+
+  if ((CURRENT == 2)); then
+    _ego-modulelist
+  else
+    shift words
+    (( CURRENT -- ))
+    curcontext="${curcontext%:*:*}:ego-$words[1]:"
+    _call_function ret _ego-$words[1]
+  fi
+}
+
+compdef _ego-profile epro
+compdef _ego ego

--- a/completion/zsh/_ego
+++ b/completion/zsh/_ego
@@ -43,7 +43,7 @@ _epro-mixins-choices() {
 
 _epro-subarch-choices() {
   local line
-  local arch=$(cat /etc/portage/make.profile/parent|grep "funtoo/1.0/linux-gnu/arch/[^/]\+$"|sed "s:^.*/\([^/]\+\)$:\1:")
+  local arch=$(grep "funtoo/1.0/linux-gnu/arch/[^/]\+$" /etc/portage/make.profile/parent|sed "s:^.*/\([^/]\+\)$:\1:")
   local -a choices
 
   _call_program help-command "ls -1 $PROFILE_DIR/arch/$arch/subarch" | while read -A line; do choices=($line $choices) done

--- a/completion/zsh/_ego
+++ b/completion/zsh/_ego
@@ -1,0 +1,72 @@
+#compdef epro
+
+PROFILE_DIR="/usr/portage/profiles/funtoo/1.0/linux-gnu"
+
+_epro-actionlist() {
+  local -a actions
+
+  actions=( 'show' 'list' 'flavor' 'mix-ins' 'subarch' 'arch' 'build' )
+
+  _values 'Actions' $actions && return 0
+}
+
+_epro-list() {
+  local -a profiles
+
+  profiles=( 'flavor' 'mix-ins' 'subarch' 'arch' 'build' )
+
+  _values 'Profiles' $profiles && return 0
+}
+
+_epro-fetch-choices() {
+  local line
+  local profile=$1
+  local -a choices
+
+  choices=()
+
+  _call_program help-command "ls -1 $PROFILE_DIR/$profile" | while read -A line; do choices=($line $choices) done
+
+  _values "Choices" $choices && return 0
+}
+
+_epro-mixins-choices() {
+  local line
+  local -a choices
+
+  choices=()
+
+  _call_program help-command "ls -1 $PROFILE_DIR/mix-ins" | while read -A line; do choices=(+$line -$line $choices) done
+
+  _values "Choices" $choices && return 0
+}
+
+_epro-subarch-choices() {
+  local line
+  local arch=$(cat /etc/portage/make.profile/parent|grep "funtoo/1.0/linux-gnu/arch/[^/]\+$"|sed "s:^.*/\([^/]\+\)$:\1:")
+  local -a choices
+
+  _call_program help-command "ls -1 $PROFILE_DIR/arch/$arch/subarch" | while read -A line; do choices=($line $choices) done
+
+  _values "Choices" $choices && return 0
+}
+
+_epro() {
+  local curcontext="$curcontext" ret=1
+
+  if ((CURRENT == 2)); then
+    _epro-actionlist
+  elif ((CURRENT == 3)); then
+    if [[ $words[2] == list ]]; then
+      _epro-list
+    elif [[ $words[2] == mix-ins ]]; then
+      _epro-mixins-choices
+    elif [[ $words[2] == subarch ]]; then
+      _epro-subarch-choices
+    elif [[ $words[2] == (flavor|arch|build) ]]; then
+      _epro-fetch-choices $words[2]
+    fi
+  fi
+}
+
+compdef _epro epro

--- a/contrib/completion/zsh/_ego
+++ b/contrib/completion/zsh/_ego
@@ -59,7 +59,11 @@ _epro-mixins-choices() {
 }
 
 _epro-subarch-choices() {
-  local arch=$(grep "$profile_dir/arch/[^/]\+$" $base_profile|sed "s:^.*/\([^/]\+\)$:\1:")
+  local arch
+
+  while read -r parentpro; do
+    [[ $parentpro == *":$profile_dir/arch/"* ]] && arch=${${parentpro##*/arch/}%%/*}
+  done < $base_profile
 
   _epro-fetch-choices arch/$arch/subarch
 }

--- a/contrib/completion/zsh/_ego
+++ b/contrib/completion/zsh/_ego
@@ -14,7 +14,7 @@ base_profile="/etc/portage/make.profile/parent"
 _ego-modulelist() {
   local -a modules
 
-  modules=( 'profile' )
+  modules=( 'profile' 'info' 'help' )
 
   _values 'Modules' $modules && ret=0
 }
@@ -23,6 +23,8 @@ _epro-actionlist() {
   local -a actions
 
   actions=( 'show' 'list' 'flavor' 'mix-ins' 'subarch' 'arch' 'build' )
+
+  [[ $curcontext == ":complete:ego-profile:" ]] && actions=( 'info' 'help' $actions )
 
   _values 'Actions' $actions && ret=0
 }

--- a/contrib/completion/zsh/_ego
+++ b/contrib/completion/zsh/_ego
@@ -1,6 +1,15 @@
 #compdef epro ego
 
-PROFILE_DIR="/usr/portage/profiles/funtoo/1.0/linux-gnu"
+# vim: set et sw=2 sts=2 ts=2 ft=zsh :
+# ZSH completion for `ego`
+# Written by Antoine Pinsard <antoine.pinsard@gmail.com>
+
+while read -r portdir; do
+  [[ $portdir == 'PORTDIR='* ]] && eval $portdir
+done < <(emerge --info)
+
+profile_dir="funtoo/1.0/linux-gnu"
+base_profile="/etc/portage/make.profile/parent"
 
 _ego-modulelist() {
   local -a modules
@@ -31,32 +40,31 @@ _epro-fetch-choices() {
   local profile=$1
   local -a choices
 
-  choices=()
-
-  _call_program help-command "ls -1 $PROFILE_DIR/$profile" | while read -A line; do choices=($line $choices) done
+  choices=("$PORTDIR"/profiles/$profile_dir/$profile/*(/N:t))
 
   _values "Choices" $choices && ret=0
 }
 
 _epro-mixins-choices() {
   local line
+  local -a mixins
   local -a choices
 
   choices=()
-
-  _call_program help-command "ls -1 $PROFILE_DIR/mix-ins" | while read -A line; do choices=(+$line -$line $choices) done
+  mixins=("$PORTDIR"/profiles/$profile_dir/mix-ins/*(/N:t))
+  for choice in $choices; do
+    choices=(+$choice -$choice $choices)
+  done
 
   _values "Choices" $choices && ret=0
 }
 
 _epro-subarch-choices() {
   local line
-  local arch=$(grep "funtoo/1.0/linux-gnu/arch/[^/]\+$" /etc/portage/make.profile/parent|sed "s:^.*/\([^/]\+\)$:\1:")
+  local arch=$(grep "$profile_dir/arch/[^/]\+$" $base_profile|sed "s:^.*/\([^/]\+\)$:\1:")
   local -a choices
 
-  _call_program help-command "ls -1 $PROFILE_DIR/arch/$arch/subarch" | while read -A line; do choices=($line $choices) done
-
-  _values "Choices" $choices && ret=0
+  _epro-fetch-choices arch/$arch/subarch
 }
 
 _ego-profile() {

--- a/contrib/completion/zsh/_ego
+++ b/contrib/completion/zsh/_ego
@@ -36,7 +36,6 @@ _epro-list() {
 }
 
 _epro-fetch-choices() {
-  local line
   local profile=$1
   local -a choices
 
@@ -60,9 +59,7 @@ _epro-mixins-choices() {
 }
 
 _epro-subarch-choices() {
-  local line
   local arch=$(grep "$profile_dir/arch/[^/]\+$" $base_profile|sed "s:^.*/\([^/]\+\)$:\1:")
-  local -a choices
 
   _epro-fetch-choices arch/$arch/subarch
 }

--- a/contrib/completion/zsh/_ego
+++ b/contrib/completion/zsh/_ego
@@ -45,7 +45,6 @@ _epro-fetch-choices() {
 }
 
 _epro-mixins-choices() {
-  local line
   local -a mixins
   local -a choices
 


### PR DESCRIPTION
Zsh completion to be included when "zsh-completion" USE flag is set.

<del>I'm not quite sure about:</del>

 * <del>The `PROFILE_DIR` variable</del>
 * <del>The  `grep "funtoo/1.0/linux-gnu/arch/[^/]\+$" /etc/portage/make.profile/parent | sed "s:^.*/\([^/]\+\)$:\1:"` command to retrieve arch</del>

A big thank you to \_`\_ for reviewing the script and pointing out some sh/zsh features.