### PR TITLE
Allow for symlinked /var/git/meta-repo

### DIFF
--- a/modules/sync.ego
+++ b/modules/sync.ego
@@ -19,6 +19,8 @@ class Module(EgoModule):
 			root = self.config.meta_repo_root
 			if not os.path.exists(os.path.dirname(root)):
 				os.makedirs(os.path.dirname(root))
+			if os.path.islink(root):
+				root = os.readlink(root)
 			self._root = root
 		return self._root
 


### PR DESCRIPTION
I ran into an issue today where I was getting the following error

Repository is at /var/git/meta-repo is read-only. Cannot update.

I traced the issue back to the fact that my /var/git/meta-repo folder was symlinked to another folder. Therefore when ego tried to change the owner to portage it only changed the owner of the symlink. That left the folder owned by root and therefore not writeable to portage.

This change simply checks to see if /var/git/meta-repo is symlinked and uses the actual folder for all operations. This cleared up my error immediate.