### PR TITLE
FL-6104: Add Grub menuentry flags support to boot-update

### DIFF
--- a/python/funtoo/boot/config.py
+++ b/python/funtoo/boot/config.py
@@ -220,7 +220,7 @@ class BootConfigFile(config.ConfigFile):
 			"boot": ["path", "generate", "timeout", "default", "bootdev", "terminal", "autopick"],
 			"display": ["gfxmode", "background", "font"],
 			"color": ["normal", "highlight"],
-			"default": ["scan", "gfxmode", "kernel", "initrd", "params", "type", "xenkernel", "xenparams", "attemptparams"],
+			"default": ["scan", "gfxmode", "kernel", "initrd", "params", "type", "xenkernel", "xenparams", "attemptparams", "menuflags"],
 			"grub": ["dir", "file", "grub-mkdevicemap", "grub-probe", "font_src"],
 			"grub-legacy": ["dir", "file"],
 			"lilo": ["file", "bin", "gparams"],

--- a/python/funtoo/boot/extensions/grub.py
+++ b/python/funtoo/boot/extensions/grub.py
@@ -121,10 +121,11 @@ class GRUBExtension(Extension):
 		params = self.boot_config["{s}/params".format(s=sect)].split()
 		myroot = self.resolver.GetParam(params, "root=")
 		mychainloader = self.resolver.GetParam(params, "chainloader=")
+		menuflags = self.boot_config["{s}/menuflags".format(s=sect)]
 		myname = sect
 		# TODO check for valid root entry
 		boot_menu.lines.append("")
-		boot_menu.lines.append("menuentry \"{mn}\" {{".format(mn=myname))
+		boot_menu.lines.append("menuentry \"{mn}\" {mf} {{".format(mn=myname, mf=menuflags))
 		if mytype in ["linux16"]:
 			k = self.resolver.strip_mount_point(self.boot_config[sect + "/kernel"])
 			full_k = os.path.join(self.boot_config["boot/path"], k.lstrip("/"))
@@ -153,7 +154,8 @@ class GRUBExtension(Extension):
 		mytype = self.boot_config["{s}/type".format(s=sect)]
 		boot_menu.lines.append("")
 		label = self.resolver.GetBootEntryString(sect, k_full_path)
-		boot_menu.lines.append("menuentry \"{l}\" {{".format(l=label))
+		menuflags = self.boot_config["{s}/menuflags".format(s=sect)]
+		boot_menu.lines.append("menuentry \"{l}\" {mf} {{".format(l=label, mf=menuflags))
 		
 		# TODO: add last-selected, which is different than last-booted.
 		#if self.config["boot/autopick"] == "last-booted":


### PR DESCRIPTION
https://bugs.funtoo.org/browse/FL-6104

Add Grub menuentry flags support to boot-update

Add support for generating Grub menu entries with flags, such as:
```
menuentry "The Mighty Funtoo Linux Kernel" --unrestricted {
}
```