### PR TITLE
Fix success value

### DIFF
--- a/modules/sync.ego
+++ b/modules/sync.ego
@@ -319,7 +319,7 @@ priority = %s
 					else:
 						retval = sync_func()
 					we_synced = True
-					if retval not in [ 0, 256]:
+					if retval not in [ 0, 256, True]:
 						we_synced_successfully = False
 						self.kits_retval["fails"].append((kt, branch, retval))
 				if success:


### PR DESCRIPTION
The sync_func may return True on success in the following cases:
  1) `kit.checkout` returns a boolean value;
  2) the same SHA1 and desired SHA1 hashes.  
  